### PR TITLE
HMACによる認証処理追加

### DIFF
--- a/function.py
+++ b/function.py
@@ -1,14 +1,21 @@
 #coding: UTF-8
+import json
+import hashlib
+import hmac
 from requests_oauthlib import OAuth1Session
 from datetime import datetime
 import settings
 
 def lambda_handler(event, context):
-    twitter = OAuth1Session(settings.CONSUMER_KEY, settings.CONSUMER_SECRET, settings.ACCESS_TOKEN, settings.ACCESS_TOKEN_SECRET)
+    # HMAC値による簡易認証処理
+    signature = event['headers']['X-Hub-Signature']
+    signedBody = "sha1=" + hmac.new(bytes(settings.SECRET, 'ascii'), bytes(event['body'], 'ascii'), hashlib.sha1).hexdigest()
+    if(signature != signedBody):
+        return {"statusCode": 401, "body": "Unauthorized" }
 
+    twitter = OAuth1Session(settings.CONSUMER_KEY, settings.CONSUMER_SECRET, settings.ACCESS_TOKEN, settings.ACCESS_TOKEN_SECRET)
     params = {"status": "テストツイートしてるぞー(" + datetime.now().strftime("%H:%M:%S") + ")"}
     req = twitter.post("https://api.twitter.com/1.1/statuses/update.json",params = params)
     
-    print('つぶやけたぞー')
-    
     return {"statusCode": 200, "body": "つぶやけたぞー" }
+

--- a/function.py
+++ b/function.py
@@ -9,7 +9,7 @@ import settings
 def lambda_handler(event, context):
     # HMAC値による簡易認証処理
     signature = event['headers']['X-Hub-Signature']
-    signedBody = "sha1=" + hmac.new(bytes(settings.SECRET, 'ascii'), bytes(event['body'], 'ascii'), hashlib.sha1).hexdigest()
+    signedBody = "sha1=" + hmac.new(bytes(settings.SECRET, 'utf-8'), bytes(event['body'], 'utf-8'), hashlib.sha1).hexdigest()
     if(signature != signedBody):
         return {"statusCode": 401, "body": "Unauthorized" }
 


### PR DESCRIPTION
#14 の対応です。

# 参考URL
[Github serviceをwebhookに変更した](https://tech.actindi.net/2019/01/15/083222)
[GitHub Webhookのpassword機構とPythonで戯れる](https://qiita.com/amedama/items/ee946e1a39517bafa933)
[HMACをいろんな言語で](https://qiita.com/takaki@github/items/8665e6c518e377840495)
[Salt と HMAC の違い](https://qiita.com/y_yoda/items/d586252b740c0c87f932)